### PR TITLE
expand laravel skeleton

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migração para Laravel
+
+Este repositório contém código legado em CakePHP 2. Para iniciar a migração:
+
+1. Gere o projeto Laravel dentro do diretório `backend` (veja `backend/README.md`).
+2. Reimplemente aos poucos os controllers e models do CakePHP em Laravel. Exemplos iniciais foram adicionados para `Fornecedor` e `Material`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,9 @@
+# Backend (Laravel)
+
+Este diretório contém a base para o backend em Laravel. Para gerar o projeto execute:
+
+```bash
+composer create-project laravel/laravel .
+```
+
+Após a criação, implemente os controladores e modelos conforme os exemplos em `app/Http/Controllers`. Atualmente existem implementações iniciais para `Fornecedor` e `Material`.

--- a/backend/app/Http/Controllers/FornecedorController.php
+++ b/backend/app/Http/Controllers/FornecedorController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Fornecedor;
+use Illuminate\Http\Request;
+
+class FornecedorController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->query('search');
+        $query = Fornecedor::query();
+        if ($search) {
+            $query->where('nome_fantasia', 'like', "%{$search}%");
+        }
+        return $query->paginate(20);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'cnpj' => 'required|unique:fornecedores,cnpj',
+            'nome_fantasia' => 'required',
+        ]);
+        $fornecedor = Fornecedor::create($data);
+        return response()->json($fornecedor, 201);
+    }
+
+    public function show(Fornecedor $fornecedor)
+    {
+        return $fornecedor;
+    }
+
+    public function update(Request $request, Fornecedor $fornecedor)
+    {
+        $fornecedor->update($request->all());
+        return $fornecedor;
+    }
+
+    public function destroy(Fornecedor $fornecedor)
+    {
+        $fornecedor->delete();
+        return response()->noContent();
+    }
+}

--- a/backend/app/Http/Controllers/MaterialController.php
+++ b/backend/app/Http/Controllers/MaterialController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Material;
+use Illuminate\Http\Request;
+
+class MaterialController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->query('search');
+        $query = Material::query();
+        if ($search) {
+            $query->where('nome', 'like', "%{$search}%")
+                  ->orWhere('barcode', 'like', "%{$search}%")
+                  ->orWhere('id', 'like', "%{$search}%")
+                  ->orWhere('descricao', 'like', "%{$search}%");
+        }
+        return $query->paginate(20);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'barcode' => 'nullable|unique:materiais,barcode',
+            'descricao' => 'nullable'
+        ]);
+        $material = Material::create($data);
+        return response()->json($material, 201);
+    }
+
+    public function show(Material $material)
+    {
+        return $material;
+    }
+
+    public function update(Request $request, Material $material)
+    {
+        $material->update($request->all());
+        return $material;
+    }
+
+    public function destroy(Material $material)
+    {
+        $material->delete();
+        return response()->noContent();
+    }
+}

--- a/backend/app/Models/Fornecedor.php
+++ b/backend/app/Models/Fornecedor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Fornecedor extends Model
+{
+    protected $table = 'fornecedores';
+    protected $guarded = [];
+}

--- a/backend/app/Models/Material.php
+++ b/backend/app/Models/Material.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Material extends Model
+{
+    protected $table = 'materiais';
+    protected $guarded = [];
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\FornecedorController;
+use App\Http\Controllers\MaterialController;
+
+Route::apiResource('fornecedores', FornecedorController::class);
+Route::apiResource('materiais', MaterialController::class);


### PR DESCRIPTION
## Summary
- drop Angular placeholder directory
- rewrite migration notes for Laravel-only
- expand Laravel backend README
- add Material controller and model examples
- expose `materiais` route

## Testing
- `php -l backend/app/Http/Controllers/FornecedorController.php` *(fails: php not installed)*
- `php -l backend/app/Http/Controllers/MaterialController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c67c974a0832b9fc36356216d013d